### PR TITLE
Allow the user to pass an arbitrary useragent object.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 Revision history for Net-Google-Analytics-MeasurementProtocol
+    - allow a useragent to be supplied to the constructor via ua_object (Olaf Alders)
 
 0.3 2015-05-28
     - fixed errors in olders perls.

--- a/lib/Net/Google/Analytics/MeasurementProtocol.pm
+++ b/lib/Net/Google/Analytics/MeasurementProtocol.pm
@@ -206,6 +206,11 @@ String. B<Defaults to "app">. Indicates the data source of the hit.
 =item * ua (for "user agent")
 String. Defaults to "Net::Google::Analytics::MeasurementProtocol/$VERSION".
 
+=item * ua_object
+
+Object.  Either a L<Furl> object, L<LWP::UserAgent> or something with inherits
+from L<LWP::UserAgent>, like L<WWW::Mechanize>. Defaults to using L<Furl>.
+
 =back
 
 =head3 Other parameters

--- a/t/02-hits.t
+++ b/t/02-hits.t
@@ -17,13 +17,13 @@ else {
     diag q(JSON looks missing. We'll make due with regexes);
 }
 
+test_pageview();
+
 my $has_lwp = eval {
     require LWP::UserAgent;
     require LWP::Protocol::https;
     1;
 };
-
-test_pageview();
 
 SKIP: {
     skip 'LWP::Protocol::https is likely not installed', 2, unless $has_lwp;


### PR DESCRIPTION
The purpose behind this is to make it easy to mock network calls in a
test environment.  This is very easy to do with something like
Test::LWP::UserAgent, but more difficult to do with Furl.  The
difference between the two classes is one argument to the post() method.
Furl needs the headers passes as an undef and with LWP::UserAgent, you
can just omit the headers entirely.
