### PR TITLE
Scrub ua_object param before POST to GA.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,9 @@
 Revision history for Net-Google-Analytics-MeasurementProtocol
 
+    - ensure ua_object is not sent in POST to Google Analytics
+
 0.4 2016-03-28
-    - allow a useragent to be supplied to the constructor via ua_object (Olaf Alders)
+    - allow a user agent to be supplied to the constructor via ua_object (Olaf Alders)
 
 0.3 2015-05-28
     - fixed errors in olders perls.

--- a/lib/Net/Google/Analytics/MeasurementProtocol.pm
+++ b/lib/Net/Google/Analytics/MeasurementProtocol.pm
@@ -24,7 +24,7 @@ sub new {
     $args{an}  ||= 'My App';
     $args{ds}  ||= 'app';
 
-    my $ua_object = $args{ua_object} || _build_user_agent( $args{ua} );
+    my $ua_object = delete $args{ua_object} || _build_user_agent( $args{ua} );
     unless ( $ua_object->isa('Furl') || $ua_object->isa('LWP::UserAgent') ) {
         Carp::croak('ua_object must be of type Furl or LWP::UserAgent');
     }
@@ -38,6 +38,12 @@ sub new {
 }
 
 sub send {
+    my ($self, $hit_type, $args) = @_;
+
+    return $self->_request( $self->_build_request_args( $hit_type, $args ) );
+}
+
+sub _build_request_args {
     my ($self, $hit_type, $args) = @_;
 
     my %args = (%{$self->{args}}, %$args, t => $hit_type);
@@ -59,8 +65,7 @@ sub send {
     }
     Carp::croak('for "pageview" hit types you must set either "dl" or both "dh" and "dp"')
         if $hit_type eq 'pageview' && !($args{dl} || ($args{dh} && $args{dp}));
-
-    return $self->_request(\%args);
+    return \%args;
 }
 
 sub _request {

--- a/t/03-args.t
+++ b/t/03-args.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+use Furl;
+use Net::Google::Analytics::MeasurementProtocol;
+
+my $ga = Net::Google::Analytics::MeasurementProtocol->new(
+    tid       => 'UA-1234-5',
+    ua_object => Furl->new,
+);
+
+my $args = $ga->_build_request_args( 'transaction', { ti => 1 } );
+
+ok( !exists $args->{ua_object},
+    'ua_object is scrubbed from args before POST' );
+
+ok( !exists $args->{debug},
+    'debug param is scrubbed from args before POST' );


### PR DESCRIPTION
A bug was introduced in ed09f1fb5 where a ua_object param gets POSTed to
Google Analytics in the form of something like:
MM::WWW::Mechanize=HASH(0x107b0de8)  This doesn't seem to cause the
request to fail, but it really shouldn't be there. :)

My apologies.  I didn't see this until I was inspecting the outgoing POST this morning.
